### PR TITLE
Okta test fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ dist/
 
 #mac files
 .DS_Store
+
+.panther/*
+panther_content/

--- a/tests/providers/okta/test_rules_admin_actions.py
+++ b/tests/providers/okta/test_rules_admin_actions.py
@@ -12,7 +12,6 @@ class TestRulesAdminActions(unittest.TestCase):
             overrides=detection.RuleOverrides(name=name_override)
         )
 
-        self.assertIsInstance(rule, detection.Rule)
         self.assertEqual(rule.name, name_override)
 
     def test_admin_role_assigned(self) -> None:
@@ -21,7 +20,6 @@ class TestRulesAdminActions(unittest.TestCase):
             overrides=detection.RuleOverrides(name=name_override)
         )
 
-        self.assertIsInstance(rule, detection.Rule)
         self.assertEqual(rule.name, name_override)
 
         evt = PantherEvent(json.loads(okta.sample_logs.admin_access_assigned))

--- a/tests/providers/okta/test_rules_api_keys.py
+++ b/tests/providers/okta/test_rules_api_keys.py
@@ -11,7 +11,6 @@ class TestRulesAPIKeys(unittest.TestCase):
             overrides=detection.RuleOverrides(name=name_override)
         )
 
-        self.assertIsInstance(rule, detection.Rule)
         self.assertEqual(rule.name, name_override)
 
     def test_api_key_created(self) -> None:
@@ -20,5 +19,4 @@ class TestRulesAPIKeys(unittest.TestCase):
             overrides=detection.RuleOverrides(name=name_override)
         )
 
-        self.assertIsInstance(rule, detection.Rule)
         self.assertEqual(rule.name, name_override)

--- a/tests/providers/okta/test_rules_improbable_access.py
+++ b/tests/providers/okta/test_rules_improbable_access.py
@@ -18,7 +18,6 @@ class TestRulesImprobableAccess(unittest.TestCase):
             overrides=detection.RuleOverrides(name=name_override)
         )
 
-        self.assertIsInstance(rule, detection.Rule)
         self.assertEqual(rule.name, name_override)
 
     def test_improbable_access_group_by(self) -> None:

--- a/tests/providers/okta/test_rules_support_actions.py
+++ b/tests/providers/okta/test_rules_support_actions.py
@@ -8,7 +8,6 @@ class TestSupportActions(unittest.TestCase):
     def test_account_support_access_defaults(self) -> None:
         rule = okta.rules.account_support_access()
 
-        self.assertIsInstance(rule, detection.Rule)
         self.assertEqual(rule.rule_id, "Okta.Support.Access")
 
     def test_account_support_access_name_override(self) -> None:
@@ -17,7 +16,6 @@ class TestSupportActions(unittest.TestCase):
             overrides=detection.RuleOverrides(name=name_override)
         )
 
-        self.assertIsInstance(rule, detection.Rule)
         self.assertEqual(rule.name, name_override)
 
     def test_account_support_reset(self) -> None:
@@ -26,5 +24,4 @@ class TestSupportActions(unittest.TestCase):
             overrides=detection.RuleOverrides(name=name_override)
         )
 
-        self.assertIsInstance(rule, detection.Rule)
         self.assertEqual(rule.name, name_override)


### PR DESCRIPTION
### Background

Removing self.assertIsInstance() of initial tests. 
Remove python_cache and update .gitignore.

### Testing

`make test`
