### PR TITLE
accessibility settings and converting to python unittest from nose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 dirs := panther_detections
-max_line_len := 120
+max_line_len := 100
 
 lint: lint-pylint lint-fmt
 
@@ -15,11 +15,11 @@ lint-fmt:
 	pipenv run black --line-length=$(max_line_len) --check $(dirs)
 
 fmt:
-	pipenv run isort --profile=black $(dirs)
+	pipenv run isort --profile=black -l $(max_line_len) $(dirs)
 	pipenv run black --line-length=$(max_line_len) $(dirs)
 
 install:
-	pipenv install --dev
+	pipenv sync --dev
 
 test: 
 	pipenv run nosetests -v --with-coverage --cover-html --cover-html-dir=htmlcov

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,9 @@ install:
 	pipenv sync --dev
 
 test: 
-	pipenv run nosetests -v --with-coverage --cover-html --cover-html-dir=htmlcov
+	pipenv run coverage run -m unittest discover tests
+	pipenv run coverage report
+	pipenv run coverage html
 
 docker-build:
 	docker build -t panther-detections .

--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,6 @@ mypy = "~=0.99"
 panther-analysis-tool = "~=0.19.4"
 pylint = "~=2.15.0"
 pylint-print = "~=1.0.0"
-nose = "~=1.3.7"
 twine = "*"
 coverage = "*"
 

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ pylint = "~=2.15.0"
 pylint-print = "~=1.0.0"
 nose = "~=1.3.7"
 twine = "*"
+coverage = "*"
 
 [packages]
 panther-sdk = "~=0.0.24"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4b91d1204ed371ec9bfd86fd40ab5634661dc209f92f3e29b02af44ac4d30165"
+            "sha256": "e56c72a8a388b5411f33e9a451e582fbad76409207e6fe366260bf42a23c3c9b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -231,19 +231,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:5a9d19cdd8dcec679c483408f208027e01ab2087cbc66787790036087b6737de",
-                "sha256:6c4845243d1896019646d649f1f0ff4042cedcc5db3ecfba3dc2d611ea11cd08"
+                "sha256:5d6e19d148c4a9d5d85f0d96570d11264f23db610f1e3c9a8b7e8b6898424691",
+                "sha256:990997248716f12b296d7d30b3119a93347d73b7a4831c015e53aaebbd074a77"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.26.71"
+            "version": "==1.26.72"
         },
         "botocore": {
             "hashes": [
-                "sha256:40406466f5c416b1f54bfbfc11aef90d783103f7ea77a1992dcaf1768ab04e12",
-                "sha256:783e7fa97bb5bf3759e4b333b8da2bcaffdb54828ea1d759b55329cc39003b98"
+                "sha256:77fff109e1bdbf030d8400ccab9d28454c03c7be62c1696a239b21792b0873df",
+                "sha256:8710f53af0e20f08f36a3bf434d18bc7ceba5d9835495b02aedbedd35df5de9a"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.29.71"
+            "version": "==1.29.72"
         },
         "certifi": {
             "hashes": [
@@ -824,15 +824,6 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==1.0.0"
-        },
-        "nose": {
-            "hashes": [
-                "sha256:9ff7c6cc443f8c51994b34a667bbcf45afd6d945be7477b52e97516fd17c53ac",
-                "sha256:dadcddc0aefbf99eea214e0f1232b94f2fa9bd98fa8353711dacb112bfcbbb2a",
-                "sha256:f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98"
-            ],
-            "index": "pypi",
-            "version": "==1.3.7"
         },
         "panther-analysis-tool": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "526a83c46a84f94f2fd6f846a65f6cc81300fb0d1259aa13669c068b2ccb99b9"
+            "sha256": "4b91d1204ed371ec9bfd86fd40ab5634661dc209f92f3e29b02af44ac4d30165"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -57,103 +57,103 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         }
     },
     "develop": {
         "aiohttp": {
             "hashes": [
-                "sha256:02f9a2c72fc95d59b881cf38a4b2be9381b9527f9d328771e90f72ac76f31ad8",
-                "sha256:059a91e88f2c00fe40aed9031b3606c3f311414f86a90d696dd982e7aec48142",
-                "sha256:05a3c31c6d7cd08c149e50dc7aa2568317f5844acd745621983380597f027a18",
-                "sha256:08c78317e950e0762c2983f4dd58dc5e6c9ff75c8a0efeae299d363d439c8e34",
-                "sha256:09e28f572b21642128ef31f4e8372adb6888846f32fecb288c8b0457597ba61a",
-                "sha256:0d2c6d8c6872df4a6ec37d2ede71eff62395b9e337b4e18efd2177de883a5033",
-                "sha256:16c121ba0b1ec2b44b73e3a8a171c4f999b33929cd2397124a8c7fcfc8cd9e06",
-                "sha256:1d90043c1882067f1bd26196d5d2db9aa6d268def3293ed5fb317e13c9413ea4",
-                "sha256:1e56b9cafcd6531bab5d9b2e890bb4937f4165109fe98e2b98ef0dcfcb06ee9d",
-                "sha256:20acae4f268317bb975671e375493dbdbc67cddb5f6c71eebdb85b34444ac46b",
-                "sha256:21b30885a63c3f4ff5b77a5d6caf008b037cb521a5f33eab445dc566f6d092cc",
-                "sha256:21d69797eb951f155026651f7e9362877334508d39c2fc37bd04ff55b2007091",
-                "sha256:256deb4b29fe5e47893fa32e1de2d73c3afe7407738bd3c63829874661d4822d",
-                "sha256:25892c92bee6d9449ffac82c2fe257f3a6f297792cdb18ad784737d61e7a9a85",
-                "sha256:2ca9af5f8f5812d475c5259393f52d712f6d5f0d7fdad9acdb1107dd9e3cb7eb",
-                "sha256:2d252771fc85e0cf8da0b823157962d70639e63cb9b578b1dec9868dd1f4f937",
-                "sha256:2dea10edfa1a54098703cb7acaa665c07b4e7568472a47f4e64e6319d3821ccf",
-                "sha256:2df5f139233060578d8c2c975128fb231a89ca0a462b35d4b5fcf7c501ebdbe1",
-                "sha256:2feebbb6074cdbd1ac276dbd737b40e890a1361b3cc30b74ac2f5e24aab41f7b",
-                "sha256:309aa21c1d54b8ef0723181d430347d7452daaff93e8e2363db8e75c72c2fb2d",
-                "sha256:3828fb41b7203176b82fe5d699e0d845435f2374750a44b480ea6b930f6be269",
-                "sha256:398701865e7a9565d49189f6c90868efaca21be65c725fc87fc305906be915da",
-                "sha256:43046a319664a04b146f81b40e1545d4c8ac7b7dd04c47e40bf09f65f2437346",
-                "sha256:437399385f2abcd634865705bdc180c8314124b98299d54fe1d4c8990f2f9494",
-                "sha256:45d88b016c849d74ebc6f2b6e8bc17cabf26e7e40c0661ddd8fae4c00f015697",
-                "sha256:47841407cc89a4b80b0c52276f3cc8138bbbfba4b179ee3acbd7d77ae33f7ac4",
-                "sha256:4a4fbc769ea9b6bd97f4ad0b430a6807f92f0e5eb020f1e42ece59f3ecfc4585",
-                "sha256:4ab94426ddb1ecc6a0b601d832d5d9d421820989b8caa929114811369673235c",
-                "sha256:4b0f30372cef3fdc262f33d06e7b411cd59058ce9174ef159ad938c4a34a89da",
-                "sha256:4e3a23ec214e95c9fe85a58470b660efe6534b83e6cbe38b3ed52b053d7cb6ad",
-                "sha256:512bd5ab136b8dc0ffe3fdf2dfb0c4b4f49c8577f6cae55dca862cd37a4564e2",
-                "sha256:527b3b87b24844ea7865284aabfab08eb0faf599b385b03c2aa91fc6edd6e4b6",
-                "sha256:54d107c89a3ebcd13228278d68f1436d3f33f2dd2af5415e3feaeb1156e1a62c",
-                "sha256:5835f258ca9f7c455493a57ee707b76d2d9634d84d5d7f62e77be984ea80b849",
-                "sha256:598adde339d2cf7d67beaccda3f2ce7c57b3b412702f29c946708f69cf8222aa",
-                "sha256:599418aaaf88a6d02a8c515e656f6faf3d10618d3dd95866eb4436520096c84b",
-                "sha256:5bf651afd22d5f0c4be16cf39d0482ea494f5c88f03e75e5fef3a85177fecdeb",
-                "sha256:5c59fcd80b9049b49acd29bd3598cada4afc8d8d69bd4160cd613246912535d7",
-                "sha256:653acc3880459f82a65e27bd6526e47ddf19e643457d36a2250b85b41a564715",
-                "sha256:66bd5f950344fb2b3dbdd421aaa4e84f4411a1a13fca3aeb2bcbe667f80c9f76",
-                "sha256:6f3553510abdbec67c043ca85727396ceed1272eef029b050677046d3387be8d",
-                "sha256:7018ecc5fe97027214556afbc7c502fbd718d0740e87eb1217b17efd05b3d276",
-                "sha256:713d22cd9643ba9025d33c4af43943c7a1eb8547729228de18d3e02e278472b6",
-                "sha256:73a4131962e6d91109bca6536416aa067cf6c4efb871975df734f8d2fd821b37",
-                "sha256:75880ed07be39beff1881d81e4a907cafb802f306efd6d2d15f2b3c69935f6fb",
-                "sha256:75e14eac916f024305db517e00a9252714fce0abcb10ad327fb6dcdc0d060f1d",
-                "sha256:8135fa153a20d82ffb64f70a1b5c2738684afa197839b34cc3e3c72fa88d302c",
-                "sha256:84b14f36e85295fe69c6b9789b51a0903b774046d5f7df538176516c3e422446",
-                "sha256:86fc24e58ecb32aee09f864cb11bb91bc4c1086615001647dbfc4dc8c32f4008",
-                "sha256:87f44875f2804bc0511a69ce44a9595d5944837a62caecc8490bbdb0e18b1342",
-                "sha256:88c70ed9da9963d5496d38320160e8eb7e5f1886f9290475a881db12f351ab5d",
-                "sha256:88e5be56c231981428f4f506c68b6a46fa25c4123a2e86d156c58a8369d31ab7",
-                "sha256:89d2e02167fa95172c017732ed7725bc8523c598757f08d13c5acca308e1a061",
-                "sha256:8d6aaa4e7155afaf994d7924eb290abbe81a6905b303d8cb61310a2aba1c68ba",
-                "sha256:92a2964319d359f494f16011e23434f6f8ef0434acd3cf154a6b7bec511e2fb7",
-                "sha256:96372fc29471646b9b106ee918c8eeb4cca423fcbf9a34daa1b93767a88a2290",
-                "sha256:978b046ca728073070e9abc074b6299ebf3501e8dee5e26efacb13cec2b2dea0",
-                "sha256:9c7149272fb5834fc186328e2c1fa01dda3e1fa940ce18fded6d412e8f2cf76d",
-                "sha256:a0239da9fbafd9ff82fd67c16704a7d1bccf0d107a300e790587ad05547681c8",
-                "sha256:ad5383a67514e8e76906a06741febd9126fc7c7ff0f599d6fcce3e82b80d026f",
-                "sha256:ad61a9639792fd790523ba072c0555cd6be5a0baf03a49a5dd8cfcf20d56df48",
-                "sha256:b29bfd650ed8e148f9c515474a6ef0ba1090b7a8faeee26b74a8ff3b33617502",
-                "sha256:b97decbb3372d4b69e4d4c8117f44632551c692bb1361b356a02b97b69e18a62",
-                "sha256:ba71c9b4dcbb16212f334126cc3d8beb6af377f6703d9dc2d9fb3874fd667ee9",
-                "sha256:c37c5cce780349d4d51739ae682dec63573847a2a8dcb44381b174c3d9c8d403",
-                "sha256:c971bf3786b5fad82ce5ad570dc6ee420f5b12527157929e830f51c55dc8af77",
-                "sha256:d1fde0f44029e02d02d3993ad55ce93ead9bb9b15c6b7ccd580f90bd7e3de476",
-                "sha256:d24b8bb40d5c61ef2d9b6a8f4528c2f17f1c5d2d31fed62ec860f6006142e83e",
-                "sha256:d5ba88df9aa5e2f806650fcbeedbe4f6e8736e92fc0e73b0400538fd25a4dd96",
-                "sha256:d6f76310355e9fae637c3162936e9504b4767d5c52ca268331e2756e54fd4ca5",
-                "sha256:d737fc67b9a970f3234754974531dc9afeea11c70791dcb7db53b0cf81b79784",
-                "sha256:da22885266bbfb3f78218dc40205fed2671909fbd0720aedba39b4515c038091",
-                "sha256:da37dcfbf4b7f45d80ee386a5f81122501ec75672f475da34784196690762f4b",
-                "sha256:db19d60d846283ee275d0416e2a23493f4e6b6028825b51290ac05afc87a6f97",
-                "sha256:db4c979b0b3e0fa7e9e69ecd11b2b3174c6963cebadeecfb7ad24532ffcdd11a",
-                "sha256:e164e0a98e92d06da343d17d4e9c4da4654f4a4588a20d6c73548a29f176abe2",
-                "sha256:e168a7560b7c61342ae0412997b069753f27ac4862ec7867eff74f0fe4ea2ad9",
-                "sha256:e381581b37db1db7597b62a2e6b8b57c3deec95d93b6d6407c5b61ddc98aca6d",
-                "sha256:e65bc19919c910127c06759a63747ebe14f386cda573d95bcc62b427ca1afc73",
-                "sha256:e7b8813be97cab8cb52b1375f41f8e6804f6507fe4660152e8ca5c48f0436017",
-                "sha256:e8a78079d9a39ca9ca99a8b0ac2fdc0c4d25fc80c8a8a82e5c8211509c523363",
-                "sha256:ebf909ea0a3fc9596e40d55d8000702a85e27fd578ff41a5500f68f20fd32e6c",
-                "sha256:ec40170327d4a404b0d91855d41bfe1fe4b699222b2b93e3d833a27330a87a6d",
-                "sha256:f178d2aadf0166be4df834c4953da2d7eef24719e8aec9a65289483eeea9d618",
-                "sha256:f88df3a83cf9df566f171adba39d5bd52814ac0b94778d2448652fc77f9eb491",
-                "sha256:f973157ffeab5459eefe7b97a804987876dd0a55570b8fa56b4e1954bf11329b",
-                "sha256:ff25f48fc8e623d95eca0670b8cc1469a83783c924a602e0fbd47363bb54aaca"
+                "sha256:03543dcf98a6619254b409be2d22b51f21ec66272be4ebda7b04e6412e4b2e14",
+                "sha256:03baa76b730e4e15a45f81dfe29a8d910314143414e528737f8589ec60cf7391",
+                "sha256:0a63f03189a6fa7c900226e3ef5ba4d3bd047e18f445e69adbd65af433add5a2",
+                "sha256:10c8cefcff98fd9168cdd86c4da8b84baaa90bf2da2269c6161984e6737bf23e",
+                "sha256:147ae376f14b55f4f3c2b118b95be50a369b89b38a971e80a17c3fd623f280c9",
+                "sha256:176a64b24c0935869d5bbc4c96e82f89f643bcdf08ec947701b9dbb3c956b7dd",
+                "sha256:17b79c2963db82086229012cff93ea55196ed31f6493bb1ccd2c62f1724324e4",
+                "sha256:1a45865451439eb320784918617ba54b7a377e3501fb70402ab84d38c2cd891b",
+                "sha256:1b3ea7edd2d24538959c1c1abf97c744d879d4e541d38305f9bd7d9b10c9ec41",
+                "sha256:22f6eab15b6db242499a16de87939a342f5a950ad0abaf1532038e2ce7d31567",
+                "sha256:3032dcb1c35bc330134a5b8a5d4f68c1a87252dfc6e1262c65a7e30e62298275",
+                "sha256:33587f26dcee66efb2fff3c177547bd0449ab7edf1b73a7f5dea1e38609a0c54",
+                "sha256:34ce9f93a4a68d1272d26030655dd1b58ff727b3ed2a33d80ec433561b03d67a",
+                "sha256:3a80464982d41b1fbfe3154e440ba4904b71c1a53e9cd584098cd41efdb188ef",
+                "sha256:3b90467ebc3d9fa5b0f9b6489dfb2c304a1db7b9946fa92aa76a831b9d587e99",
+                "sha256:3d89efa095ca7d442a6d0cbc755f9e08190ba40069b235c9886a8763b03785da",
+                "sha256:3d8ef1a630519a26d6760bc695842579cb09e373c5f227a21b67dc3eb16cfea4",
+                "sha256:3f43255086fe25e36fd5ed8f2ee47477408a73ef00e804cb2b5cba4bf2ac7f5e",
+                "sha256:40653609b3bf50611356e6b6554e3a331f6879fa7116f3959b20e3528783e699",
+                "sha256:41a86a69bb63bb2fc3dc9ad5ea9f10f1c9c8e282b471931be0268ddd09430b04",
+                "sha256:493f5bc2f8307286b7799c6d899d388bbaa7dfa6c4caf4f97ef7521b9cb13719",
+                "sha256:4a6cadebe132e90cefa77e45f2d2f1a4b2ce5c6b1bfc1656c1ddafcfe4ba8131",
+                "sha256:4c745b109057e7e5f1848c689ee4fb3a016c8d4d92da52b312f8a509f83aa05e",
+                "sha256:4d347a172f866cd1d93126d9b239fcbe682acb39b48ee0873c73c933dd23bd0f",
+                "sha256:4dac314662f4e2aa5009977b652d9b8db7121b46c38f2073bfeed9f4049732cd",
+                "sha256:4ddaae3f3d32fc2cb4c53fab020b69a05c8ab1f02e0e59665c6f7a0d3a5be54f",
+                "sha256:5393fb786a9e23e4799fec788e7e735de18052f83682ce2dfcabaf1c00c2c08e",
+                "sha256:59f029a5f6e2d679296db7bee982bb3d20c088e52a2977e3175faf31d6fb75d1",
+                "sha256:5a7bdf9e57126dc345b683c3632e8ba317c31d2a41acd5800c10640387d193ed",
+                "sha256:5b3f2e06a512e94722886c0827bee9807c86a9f698fac6b3aee841fab49bbfb4",
+                "sha256:5ce45967538fb747370308d3145aa68a074bdecb4f3a300869590f725ced69c1",
+                "sha256:5e14f25765a578a0a634d5f0cd1e2c3f53964553a00347998dfdf96b8137f777",
+                "sha256:618c901dd3aad4ace71dfa0f5e82e88b46ef57e3239fc7027773cb6d4ed53531",
+                "sha256:652b1bff4f15f6287550b4670546a2947f2a4575b6c6dff7760eafb22eacbf0b",
+                "sha256:6c08e8ed6fa3d477e501ec9db169bfac8140e830aa372d77e4a43084d8dd91ab",
+                "sha256:6ddb2a2026c3f6a68c3998a6c47ab6795e4127315d2e35a09997da21865757f8",
+                "sha256:6e601588f2b502c93c30cd5a45bfc665faaf37bbe835b7cfd461753068232074",
+                "sha256:6e74dd54f7239fcffe07913ff8b964e28b712f09846e20de78676ce2a3dc0bfc",
+                "sha256:7235604476a76ef249bd64cb8274ed24ccf6995c4a8b51a237005ee7a57e8643",
+                "sha256:7ab43061a0c81198d88f39aaf90dae9a7744620978f7ef3e3708339b8ed2ef01",
+                "sha256:7c7837fe8037e96b6dd5cfcf47263c1620a9d332a87ec06a6ca4564e56bd0f36",
+                "sha256:80575ba9377c5171407a06d0196b2310b679dc752d02a1fcaa2bc20b235dbf24",
+                "sha256:80a37fe8f7c1e6ce8f2d9c411676e4bc633a8462844e38f46156d07a7d401654",
+                "sha256:8189c56eb0ddbb95bfadb8f60ea1b22fcfa659396ea36f6adcc521213cd7b44d",
+                "sha256:854f422ac44af92bfe172d8e73229c270dc09b96535e8a548f99c84f82dde241",
+                "sha256:880e15bb6dad90549b43f796b391cfffd7af373f4646784795e20d92606b7a51",
+                "sha256:8b631e26df63e52f7cce0cce6507b7a7f1bc9b0c501fcde69742130b32e8782f",
+                "sha256:8c29c77cc57e40f84acef9bfb904373a4e89a4e8b74e71aa8075c021ec9078c2",
+                "sha256:91f6d540163f90bbaef9387e65f18f73ffd7c79f5225ac3d3f61df7b0d01ad15",
+                "sha256:92c0cea74a2a81c4c76b62ea1cac163ecb20fb3ba3a75c909b9fa71b4ad493cf",
+                "sha256:9bcb89336efa095ea21b30f9e686763f2be4478f1b0a616969551982c4ee4c3b",
+                "sha256:a1f4689c9a1462f3df0a1f7e797791cd6b124ddbee2b570d34e7f38ade0e2c71",
+                "sha256:a3fec6a4cb5551721cdd70473eb009d90935b4063acc5f40905d40ecfea23e05",
+                "sha256:a5d794d1ae64e7753e405ba58e08fcfa73e3fad93ef9b7e31112ef3c9a0efb52",
+                "sha256:a86d42d7cba1cec432d47ab13b6637bee393a10f664c425ea7b305d1301ca1a3",
+                "sha256:adfbc22e87365a6e564c804c58fc44ff7727deea782d175c33602737b7feadb6",
+                "sha256:aeb29c84bb53a84b1a81c6c09d24cf33bb8432cc5c39979021cc0f98c1292a1a",
+                "sha256:aede4df4eeb926c8fa70de46c340a1bc2c6079e1c40ccf7b0eae1313ffd33519",
+                "sha256:b744c33b6f14ca26b7544e8d8aadff6b765a80ad6164fb1a430bbadd593dfb1a",
+                "sha256:b7a00a9ed8d6e725b55ef98b1b35c88013245f35f68b1b12c5cd4100dddac333",
+                "sha256:bb96fa6b56bb536c42d6a4a87dfca570ff8e52de2d63cabebfd6fb67049c34b6",
+                "sha256:bbcf1a76cf6f6dacf2c7f4d2ebd411438c275faa1dc0c68e46eb84eebd05dd7d",
+                "sha256:bca5f24726e2919de94f047739d0a4fc01372801a3672708260546aa2601bf57",
+                "sha256:bf2e1a9162c1e441bf805a1fd166e249d574ca04e03b34f97e2928769e91ab5c",
+                "sha256:c4eb3b82ca349cf6fadcdc7abcc8b3a50ab74a62e9113ab7a8ebc268aad35bb9",
+                "sha256:c6cc15d58053c76eacac5fa9152d7d84b8d67b3fde92709195cb984cfb3475ea",
+                "sha256:c6cd05ea06daca6ad6a4ca3ba7fe7dc5b5de063ff4daec6170ec0f9979f6c332",
+                "sha256:c844fd628851c0bc309f3c801b3a3d58ce430b2ce5b359cd918a5a76d0b20cb5",
+                "sha256:c9cb1565a7ad52e096a6988e2ee0397f72fe056dadf75d17fa6b5aebaea05622",
+                "sha256:cab9401de3ea52b4b4c6971db5fb5c999bd4260898af972bf23de1c6b5dd9d71",
+                "sha256:cd468460eefef601ece4428d3cf4562459157c0f6523db89365202c31b6daebb",
+                "sha256:d1e6a862b76f34395a985b3cd39a0d949ca80a70b6ebdea37d3ab39ceea6698a",
+                "sha256:d1f9282c5f2b5e241034a009779e7b2a1aa045f667ff521e7948ea9b56e0c5ff",
+                "sha256:d265f09a75a79a788237d7f9054f929ced2e69eb0bb79de3798c468d8a90f945",
+                "sha256:db3fc6120bce9f446d13b1b834ea5b15341ca9ff3f335e4a951a6ead31105480",
+                "sha256:dbf3a08a06b3f433013c143ebd72c15cac33d2914b8ea4bea7ac2c23578815d6",
+                "sha256:de04b491d0e5007ee1b63a309956eaed959a49f5bb4e84b26c8f5d49de140fa9",
+                "sha256:e4b09863aae0dc965c3ef36500d891a3ff495a2ea9ae9171e4519963c12ceefd",
+                "sha256:e595432ac259af2d4630008bf638873d69346372d38255774c0e286951e8b79f",
+                "sha256:e75b89ac3bd27d2d043b234aa7b734c38ba1b0e43f07787130a0ecac1e12228a",
+                "sha256:ea9eb976ffdd79d0e893869cfe179a8f60f152d42cb64622fca418cd9b18dc2a",
+                "sha256:eafb3e874816ebe2a92f5e155f17260034c8c341dad1df25672fb710627c6949",
+                "sha256:ee3c36df21b5714d49fc4580247947aa64bcbe2939d1b77b4c8dcb8f6c9faecc",
+                "sha256:f352b62b45dff37b55ddd7b9c0c8672c4dd2eb9c0f9c11d395075a84e2c40f75",
+                "sha256:fabb87dd8850ef0f7fe2b366d44b77d7e6fa2ea87861ab3844da99291e81e60f",
+                "sha256:fe11310ae1e4cd560035598c3f29d86cef39a83d244c7466f95c27ae04850f10",
+                "sha256:fe7ba4a51f33ab275515f66b0a236bcde4fb5561498fe8f898d4e549b2e4509f"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.8.3"
+            "version": "==3.8.4"
         },
         "aiosignal": {
             "hashes": [
@@ -231,18 +231,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:159ab54ab301a213aea0dbebfe97c12909fd9180110a2b78aaa712c2d7d1a929"
+                "sha256:5a9d19cdd8dcec679c483408f208027e01ab2087cbc66787790036087b6737de",
+                "sha256:6c4845243d1896019646d649f1f0ff4042cedcc5db3ecfba3dc2d611ea11cd08"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.26.67"
+            "version": "==1.26.71"
         },
         "botocore": {
             "hashes": [
-                "sha256:0ccec4a906b6b8c7bb6bc5226509059ee9ed94d3cf1014487ef5b8e56801e6a3",
-                "sha256:424c5fa21913d85ea990928acf35622a4f2b7f0750133b96adaa8c642bb6a878"
+                "sha256:40406466f5c416b1f54bfbfc11aef90d783103f7ea77a1992dcaf1768ab04e12",
+                "sha256:783e7fa97bb5bf3759e4b333b8da2bcaffdb54828ea1d759b55329cc39003b98"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.29.67"
+            "version": "==1.29.71"
         },
         "certifi": {
             "hashes": [
@@ -254,11 +255,97 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
-                "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
+                "sha256:00d3ffdaafe92a5dc603cb9bd5111aaa36dfa187c8285c543be562e61b755f6b",
+                "sha256:024e606be3ed92216e2b6952ed859d86b4cfa52cd5bc5f050e7dc28f9b43ec42",
+                "sha256:0298eafff88c99982a4cf66ba2efa1128e4ddaca0b05eec4c456bbc7db691d8d",
+                "sha256:02a51034802cbf38db3f89c66fb5d2ec57e6fe7ef2f4a44d070a593c3688667b",
+                "sha256:083c8d17153ecb403e5e1eb76a7ef4babfc2c48d58899c98fcaa04833e7a2f9a",
+                "sha256:0a11e971ed097d24c534c037d298ad32c6ce81a45736d31e0ff0ad37ab437d59",
+                "sha256:0bf2dae5291758b6f84cf923bfaa285632816007db0330002fa1de38bfcb7154",
+                "sha256:0c0a590235ccd933d9892c627dec5bc7511ce6ad6c1011fdf5b11363022746c1",
+                "sha256:0f438ae3532723fb6ead77e7c604be7c8374094ef4ee2c5e03a3a17f1fca256c",
+                "sha256:109487860ef6a328f3eec66f2bf78b0b72400280d8f8ea05f69c51644ba6521a",
+                "sha256:11b53acf2411c3b09e6af37e4b9005cba376c872503c8f28218c7243582df45d",
+                "sha256:12db3b2c533c23ab812c2b25934f60383361f8a376ae272665f8e48b88e8e1c6",
+                "sha256:14e76c0f23218b8f46c4d87018ca2e441535aed3632ca134b10239dfb6dadd6b",
+                "sha256:16a8663d6e281208d78806dbe14ee9903715361cf81f6d4309944e4d1e59ac5b",
+                "sha256:292d5e8ba896bbfd6334b096e34bffb56161c81408d6d036a7dfa6929cff8783",
+                "sha256:2c03cc56021a4bd59be889c2b9257dae13bf55041a3372d3295416f86b295fb5",
+                "sha256:2e396d70bc4ef5325b72b593a72c8979999aa52fb8bcf03f701c1b03e1166918",
+                "sha256:2edb64ee7bf1ed524a1da60cdcd2e1f6e2b4f66ef7c077680739f1641f62f555",
+                "sha256:31a9ddf4718d10ae04d9b18801bd776693487cbb57d74cc3458a7673f6f34639",
+                "sha256:356541bf4381fa35856dafa6a965916e54bed415ad8a24ee6de6e37deccf2786",
+                "sha256:358a7c4cb8ba9b46c453b1dd8d9e431452d5249072e4f56cfda3149f6ab1405e",
+                "sha256:37f8febc8ec50c14f3ec9637505f28e58d4f66752207ea177c1d67df25da5aed",
+                "sha256:39049da0ffb96c8cbb65cbf5c5f3ca3168990adf3551bd1dee10c48fce8ae820",
+                "sha256:39cf9ed17fe3b1bc81f33c9ceb6ce67683ee7526e65fde1447c772afc54a1bb8",
+                "sha256:3ae1de54a77dc0d6d5fcf623290af4266412a7c4be0b1ff7444394f03f5c54e3",
+                "sha256:3b590df687e3c5ee0deef9fc8c547d81986d9a1b56073d82de008744452d6541",
+                "sha256:3e45867f1f2ab0711d60c6c71746ac53537f1684baa699f4f668d4c6f6ce8e14",
+                "sha256:3fc1c4a2ffd64890aebdb3f97e1278b0cc72579a08ca4de8cd2c04799a3a22be",
+                "sha256:4457ea6774b5611f4bed5eaa5df55f70abde42364d498c5134b7ef4c6958e20e",
+                "sha256:44ba614de5361b3e5278e1241fda3dc1838deed864b50a10d7ce92983797fa76",
+                "sha256:4a8fcf28c05c1f6d7e177a9a46a1c52798bfe2ad80681d275b10dcf317deaf0b",
+                "sha256:4b0d02d7102dd0f997580b51edc4cebcf2ab6397a7edf89f1c73b586c614272c",
+                "sha256:502218f52498a36d6bf5ea77081844017bf7982cdbe521ad85e64cabee1b608b",
+                "sha256:503e65837c71b875ecdd733877d852adbc465bd82c768a067badd953bf1bc5a3",
+                "sha256:5995f0164fa7df59db4746112fec3f49c461dd6b31b841873443bdb077c13cfc",
+                "sha256:59e5686dd847347e55dffcc191a96622f016bc0ad89105e24c14e0d6305acbc6",
+                "sha256:601f36512f9e28f029d9481bdaf8e89e5148ac5d89cffd3b05cd533eeb423b59",
+                "sha256:608862a7bf6957f2333fc54ab4399e405baad0163dc9f8d99cb236816db169d4",
+                "sha256:62595ab75873d50d57323a91dd03e6966eb79c41fa834b7a1661ed043b2d404d",
+                "sha256:70990b9c51340e4044cfc394a81f614f3f90d41397104d226f21e66de668730d",
+                "sha256:71140351489970dfe5e60fc621ada3e0f41104a5eddaca47a7acb3c1b851d6d3",
+                "sha256:72966d1b297c741541ca8cf1223ff262a6febe52481af742036a0b296e35fa5a",
+                "sha256:74292fc76c905c0ef095fe11e188a32ebd03bc38f3f3e9bcb85e4e6db177b7ea",
+                "sha256:761e8904c07ad053d285670f36dd94e1b6ab7f16ce62b9805c475b7aa1cffde6",
+                "sha256:772b87914ff1152b92a197ef4ea40efe27a378606c39446ded52c8f80f79702e",
+                "sha256:79909e27e8e4fcc9db4addea88aa63f6423ebb171db091fb4373e3312cb6d603",
+                "sha256:7e189e2e1d3ed2f4aebabd2d5b0f931e883676e51c7624826e0a4e5fe8a0bf24",
+                "sha256:7eb33a30d75562222b64f569c642ff3dc6689e09adda43a082208397f016c39a",
+                "sha256:81d6741ab457d14fdedc215516665050f3822d3e56508921cc7239f8c8e66a58",
+                "sha256:8499ca8f4502af841f68135133d8258f7b32a53a1d594aa98cc52013fff55678",
+                "sha256:84c3990934bae40ea69a82034912ffe5a62c60bbf6ec5bc9691419641d7d5c9a",
+                "sha256:87701167f2a5c930b403e9756fab1d31d4d4da52856143b609e30a1ce7160f3c",
+                "sha256:88600c72ef7587fe1708fd242b385b6ed4b8904976d5da0893e31df8b3480cb6",
+                "sha256:8ac7b6a045b814cf0c47f3623d21ebd88b3e8cf216a14790b455ea7ff0135d18",
+                "sha256:8b8af03d2e37866d023ad0ddea594edefc31e827fee64f8de5611a1dbc373174",
+                "sha256:8c7fe7afa480e3e82eed58e0ca89f751cd14d767638e2550c77a92a9e749c317",
+                "sha256:8eade758719add78ec36dc13201483f8e9b5d940329285edcd5f70c0a9edbd7f",
+                "sha256:911d8a40b2bef5b8bbae2e36a0b103f142ac53557ab421dc16ac4aafee6f53dc",
+                "sha256:93ad6d87ac18e2a90b0fe89df7c65263b9a99a0eb98f0a3d2e079f12a0735837",
+                "sha256:95dea361dd73757c6f1c0a1480ac499952c16ac83f7f5f4f84f0658a01b8ef41",
+                "sha256:9ab77acb98eba3fd2a85cd160851816bfce6871d944d885febf012713f06659c",
+                "sha256:9cb3032517f1627cc012dbc80a8ec976ae76d93ea2b5feaa9d2a5b8882597579",
+                "sha256:9cf4e8ad252f7c38dd1f676b46514f92dc0ebeb0db5552f5f403509705e24753",
+                "sha256:9d9153257a3f70d5f69edf2325357251ed20f772b12e593f3b3377b5f78e7ef8",
+                "sha256:a152f5f33d64a6be73f1d30c9cc82dfc73cec6477ec268e7c6e4c7d23c2d2291",
+                "sha256:a16418ecf1329f71df119e8a65f3aa68004a3f9383821edcb20f0702934d8087",
+                "sha256:a60332922359f920193b1d4826953c507a877b523b2395ad7bc716ddd386d866",
+                "sha256:a8d0fc946c784ff7f7c3742310cc8a57c5c6dc31631269876a88b809dbeff3d3",
+                "sha256:ab5de034a886f616a5668aa5d098af2b5385ed70142090e2a31bcbd0af0fdb3d",
+                "sha256:c22d3fe05ce11d3671297dc8973267daa0f938b93ec716e12e0f6dee81591dc1",
+                "sha256:c2ac1b08635a8cd4e0cbeaf6f5e922085908d48eb05d44c5ae9eabab148512ca",
+                "sha256:c512accbd6ff0270939b9ac214b84fb5ada5f0409c44298361b2f5e13f9aed9e",
+                "sha256:c75ffc45f25324e68ab238cb4b5c0a38cd1c3d7f1fb1f72b5541de469e2247db",
+                "sha256:c95a03c79bbe30eec3ec2b7f076074f4281526724c8685a42872974ef4d36b72",
+                "sha256:cadaeaba78750d58d3cc6ac4d1fd867da6fc73c88156b7a3212a3cd4819d679d",
+                "sha256:cd6056167405314a4dc3c173943f11249fa0f1b204f8b51ed4bde1a9cd1834dc",
+                "sha256:db72b07027db150f468fbada4d85b3b2729a3db39178abf5c543b784c1254539",
+                "sha256:df2c707231459e8a4028eabcd3cfc827befd635b3ef72eada84ab13b52e1574d",
+                "sha256:e62164b50f84e20601c1ff8eb55620d2ad25fb81b59e3cd776a1902527a788af",
+                "sha256:e696f0dd336161fca9adbb846875d40752e6eba585843c768935ba5c9960722b",
+                "sha256:eaa379fcd227ca235d04152ca6704c7cb55564116f8bc52545ff357628e10602",
+                "sha256:ebea339af930f8ca5d7a699b921106c6e29c617fe9606fa7baa043c1cdae326f",
+                "sha256:f4c39b0e3eac288fedc2b43055cfc2ca7a60362d0e5e87a637beac5d801ef478",
+                "sha256:f5057856d21e7586765171eac8b9fc3f7d44ef39425f85dbcccb13b3ebea806c",
+                "sha256:f6f45710b4459401609ebebdbcfb34515da4fc2aa886f95107f556ac69a9147e",
+                "sha256:f97e83fa6c25693c7a35de154681fcc257c1c41b38beb0304b9c4d2d9e164479",
+                "sha256:f9d0c5c045a3ca9bedfc35dca8526798eb91a07aa7a2c0fee134c6c6f321cbd7",
+                "sha256:ff6f3db31555657f3163b15a6b7c6938d08df7adbfc9dd13d9d19edad678f1e8"
             ],
             "markers": "python_full_version >= '3.6.0'",
-            "version": "==2.1.1"
+            "version": "==3.0.1"
         },
         "click": {
             "hashes": [
@@ -275,6 +362,63 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==21.6.0"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:04481245ef966fbd24ae9b9e537ce899ae584d521dfbe78f89cad003c38ca2ab",
+                "sha256:0c45948f613d5d18c9ec5eaa203ce06a653334cf1bd47c783a12d0dd4fd9c851",
+                "sha256:10188fe543560ec4874f974b5305cd1a8bdcfa885ee00ea3a03733464c4ca265",
+                "sha256:218fe982371ac7387304153ecd51205f14e9d731b34fb0568181abaf7b443ba0",
+                "sha256:29571503c37f2ef2138a306d23e7270687c0efb9cab4bd8038d609b5c2393a3a",
+                "sha256:2a60d6513781e87047c3e630b33b4d1e89f39836dac6e069ffee28c4786715f5",
+                "sha256:2bf1d5f2084c3932b56b962a683074a3692bce7cabd3aa023c987a2a8e7612f6",
+                "sha256:3164d31078fa9efe406e198aecd2a02d32a62fecbdef74f76dad6a46c7e48311",
+                "sha256:32df215215f3af2c1617a55dbdfb403b772d463d54d219985ac7cd3bf124cada",
+                "sha256:33d1ae9d4079e05ac4cc1ef9e20c648f5afabf1a92adfaf2ccf509c50b85717f",
+                "sha256:33ff26d0f6cc3ca8de13d14fde1ff8efe1456b53e3f0273e63cc8b3c84a063d8",
+                "sha256:38da2db80cc505a611938d8624801158e409928b136c8916cd2e203970dde4dc",
+                "sha256:3b155caf3760408d1cb903b21e6a97ad4e2bdad43cbc265e3ce0afb8e0057e73",
+                "sha256:3b946bbcd5a8231383450b195cfb58cb01cbe7f8949f5758566b881df4b33baf",
+                "sha256:3baf5f126f30781b5e93dbefcc8271cb2491647f8283f20ac54d12161dff080e",
+                "sha256:4b14d5e09c656de5038a3f9bfe5228f53439282abcab87317c9f7f1acb280352",
+                "sha256:51b236e764840a6df0661b67e50697aaa0e7d4124ca95e5058fa3d7cbc240b7c",
+                "sha256:63ffd21aa133ff48c4dff7adcc46b7ec8b565491bfc371212122dd999812ea1c",
+                "sha256:6a43c7823cd7427b4ed763aa7fb63901ca8288591323b58c9cd6ec31ad910f3c",
+                "sha256:755e89e32376c850f826c425ece2c35a4fc266c081490eb0a841e7c1cb0d3bda",
+                "sha256:7a726d742816cb3a8973c8c9a97539c734b3a309345236cd533c4883dda05b8d",
+                "sha256:7c7c0d0827e853315c9bbd43c1162c006dd808dbbe297db7ae66cd17b07830f0",
+                "sha256:7ed681b0f8e8bcbbffa58ba26fcf5dbc8f79e7997595bf071ed5430d8c08d6f3",
+                "sha256:7ee5c9bb51695f80878faaa5598040dd6c9e172ddcf490382e8aedb8ec3fec8d",
+                "sha256:8361be1c2c073919500b6601220a6f2f98ea0b6d2fec5014c1d9cfa23dd07038",
+                "sha256:8ae125d1134bf236acba8b83e74c603d1b30e207266121e76484562bc816344c",
+                "sha256:9817733f0d3ea91bea80de0f79ef971ae94f81ca52f9b66500c6a2fea8e4b4f8",
+                "sha256:98b85dd86514d889a2e3dd22ab3c18c9d0019e696478391d86708b805f4ea0fa",
+                "sha256:9ccb092c9ede70b2517a57382a601619d20981f56f440eae7e4d7eaafd1d1d09",
+                "sha256:9d58885215094ab4a86a6aef044e42994a2bd76a446dc59b352622655ba6621b",
+                "sha256:b643cb30821e7570c0aaf54feaf0bfb630b79059f85741843e9dc23f33aaca2c",
+                "sha256:bc7c85a150501286f8b56bd8ed3aa4093f4b88fb68c0843d21ff9656f0009d6a",
+                "sha256:beeb129cacea34490ffd4d6153af70509aa3cda20fdda2ea1a2be870dfec8d52",
+                "sha256:c31b75ae466c053a98bf26843563b3b3517b8f37da4d47b1c582fdc703112bc3",
+                "sha256:c4e4881fa9e9667afcc742f0c244d9364d197490fbc91d12ac3b5de0bf2df146",
+                "sha256:c5b15ed7644ae4bee0ecf74fee95808dcc34ba6ace87e8dfbf5cb0dc20eab45a",
+                "sha256:d12d076582507ea460ea2a89a8c85cb558f83406c8a41dd641d7be9a32e1274f",
+                "sha256:d248cd4a92065a4d4543b8331660121b31c4148dd00a691bfb7a5cdc7483cfa4",
+                "sha256:d47dd659a4ee952e90dc56c97d78132573dc5c7b09d61b416a9deef4ebe01a0c",
+                "sha256:d4a5a5879a939cb84959d86869132b00176197ca561c664fc21478c1eee60d75",
+                "sha256:da9b41d4539eefd408c46725fb76ecba3a50a3367cafb7dea5f250d0653c1040",
+                "sha256:db61a79c07331e88b9a9974815c075fbd812bc9dbc4dc44b366b5368a2936063",
+                "sha256:ddb726cb861c3117a553f940372a495fe1078249ff5f8a5478c0576c7be12050",
+                "sha256:ded59300d6330be27bc6cf0b74b89ada58069ced87c48eaf9344e5e84b0072f7",
+                "sha256:e2617759031dae1bf183c16cef8fcfb3de7617f394c813fa5e8e46e9b82d4222",
+                "sha256:e5cdbb5cafcedea04924568d990e20ce7f1945a1dd54b560f879ee2d57226912",
+                "sha256:ec8e767f13be637d056f7e07e61d089e555f719b387a7070154ad80a0ff31801",
+                "sha256:ef382417db92ba23dfb5864a3fc9be27ea4894e86620d342a116b243ade5d35d",
+                "sha256:f2cba5c6db29ce991029b5e4ac51eb36774458f0a3b8d3137241b32d1bb91f06",
+                "sha256:f5b4198d85a3755d27e64c52f8c95d6333119e49fd001ae5798dac872c95e0f8",
+                "sha256:ffeeb38ee4a80a30a6877c5c4c359e5498eec095878f1581453202bfacc8fbc2"
+            ],
+            "index": "pypi",
+            "version": "==7.1.0"
         },
         "decorator": {
             "hashes": [
@@ -692,10 +836,10 @@
         },
         "panther-analysis-tool": {
             "hashes": [
-                "sha256:f357076a8cab570b83f306d9a6edafcfd08fc51066c1250f0d5ce2eb48fccece"
+                "sha256:727e7a13b57cb284445c228918b57af0398cb9dfb5ab0450ba9d9047383818c4"
             ],
             "index": "pypi",
-            "version": "==0.19.4"
+            "version": "==0.19.5"
         },
         "panther-core": {
             "hashes": [
@@ -771,7 +915,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
         },
         "pyyaml": {
@@ -905,7 +1049,7 @@
                 "sha256:f01da5790e95815eb5a8a138508c01c758e5f5bc0ce4286c4f7028b8dd7ac3d0",
                 "sha256:f34019dced51047d6f70cb9383b2ae2853b7fc4dce65129a5acd49f4f9256646"
             ],
-            "markers": "platform_python_implementation == 'CPython' and python_version < '3.11'",
+            "markers": "python_version < '3.11' and platform_python_implementation == 'CPython'",
             "version": "==0.2.7"
         },
         "s3transfer": {
@@ -936,7 +1080,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "smmap": {
@@ -949,11 +1093,11 @@
         },
         "stevedore": {
             "hashes": [
-                "sha256:7f8aeb6e3f90f96832c301bff21a7eb5eefbe894c88c506483d355565d88cc1a",
-                "sha256:aa6436565c069b2946fe4ebff07f5041e0c8bf18c7376dd29edf80cf7d524e4e"
+                "sha256:2c428d2338976279e8eb2196f7a94910960d9f7ba2f41f3988511e95ca447021",
+                "sha256:bd5a71ff5e5e5f5ea983880e4a1dd1bb47f8feebbb3d95b592398e2f02194771"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.1.1"
+            "version": "==5.0.0"
         },
         "tomli": {
             "hashes": [
@@ -981,11 +1125,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
-                "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"
+                "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+                "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"
             ],
             "markers": "python_version < '3.10'",
-            "version": "==4.4.0"
+            "version": "==4.5.0"
         },
         "urllib3": {
             "hashes": [
@@ -1154,11 +1298,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:6c4fe274b8f85ec73c37a8e4e3fa00df9fb9335da96fb789e3b96b318e5097b3",
-                "sha256:a3cac813d40993596b39ea9e93a18e8a2076d5c378b8bc88ec32ab264e04ad02"
+                "sha256:23f70e964bc11a34cef175bc90ba2914e1e4545ea1e3e2f67c079671883f9cb6",
+                "sha256:e8b2a36ea17df80ffe9e2c4fda3f693c3dad6df1697d3cd3af232db680950b0b"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.12.1"
+            "version": "==3.13.0"
         }
     }
 }

--- a/panther_detections/providers/crowdstrike/rules/detection_passthrough.py
+++ b/panther_detections/providers/crowdstrike/rules/detection_passthrough.py
@@ -15,7 +15,10 @@ def detection_passthrough(
     """Crowdstrike Falcon has detected malicious activity on a host."""
 
     def _title(event: PantherEvent) -> str:
-        return f"Crowdstrike Alert ({event.get('Technique')}) - {event.get('ComputerName')}({event.get('UserName')})"
+        return (
+            f"Crowdstrike Alert ({event.get('Technique')}) - "
+            f"{event.get('ComputerName')}({event.get('UserName')})"
+        )
 
     def _severity(event: PantherEvent) -> str:
         return event.get("SeverityName")

--- a/panther_detections/providers/crowdstrike/rules/dns_request.py
+++ b/panther_detections/providers/crowdstrike/rules/dns_request.py
@@ -12,10 +12,13 @@ def dns_request(
     overrides: detection.RuleOverrides = detection.RuleOverrides(),
     extensions: detection.RuleExtensions = detection.RuleExtensions(),
 ) -> detection.Rule:
-    """A DNS request was made to a domain on an explicit denylist"""
+    """A DNS request was made to a domain on an explicit denylist."""
 
     def _title(event: PantherEvent) -> str:
-        return f"A denylisted domain [{event.get('DomainName')}] was queried by host {event.get('aid')}"
+        return (
+            f"A denylisted domain [{event.get('DomainName')}] was queried by host "
+            f"{event.get('aid')}"
+        )
 
     def _dedup(event: PantherEvent) -> str:
         #  Alert on every individual lookup of a bad domain, per machine
@@ -35,7 +38,8 @@ def dns_request(
         reports={"MITRE ATT&CK": ["TA0001:T1566"]},
         severity=detection.SeverityCritical,
         description="A DNS request was made to a domain on an explicit denylist",
-        reference="https://docs.runpanther.io/data-onboarding/supported-logs/crowdstrike#crowdstrike-dnsrequest",
+        reference="https://docs.runpanther.io/data-onboarding/supported-logs/"
+        "crowdstrike#crowdstrike-dnsrequest",
         runbook="Filter for host ID in title in Crowdstrike Host Management console to "
         "identify the system that queried the domain.",
         filters=[match_filters.deep_in("DomainName", DOMAIN_DENY_LIST)],

--- a/panther_detections/providers/crowdstrike/rules/real_time_response_session.py
+++ b/panther_detections/providers/crowdstrike/rules/real_time_response_session.py
@@ -12,21 +12,30 @@ def real_time_response_session(
     overrides: detection.RuleOverrides = detection.RuleOverrides(),
     extensions: detection.RuleExtensions = detection.RuleExtensions(),
 ) -> detection.Rule:
-    """Alert when someone uses Crowdstrike’s RTR (real-time response)
-    capability to access a machine remotely to run commands."""
+    """Alert when someone uses Crowdstrike’s RTR (real-time response) capability to access a machine
+    remotely to run commands."""
 
     def _title(event: PantherEvent) -> str:
-
         user_name = event.deep_get("unknown_payload", "UserName", default="<unknown-UserName>")
-        hostname_field = event.deep_get("unknown_payload", "HostnameField", default="<unknown-HostNameField>")
-        return f"{user_name} started a Crowdstrike Real-Time Response (RTR) shell on {hostname_field}"
+        hostname_field = event.deep_get(
+            "unknown_payload", "HostnameField", default="<unknown-HostNameField>"
+        )
+        return (
+            f"{user_name} started a Crowdstrike Real-Time Response (RTR) shell on {hostname_field}"
+        )
 
     def _alert_context(event: PantherEvent) -> dict:
         return {
-            "Start Time": event.deep_get("unknown_payload", "StartTimestamp", default="<unknown-StartTimestamp>"),
-            "SessionId": event.deep_get("unknown_payload", "SessionId", default="<unknown-SessionId>"),
+            "Start Time": event.deep_get(
+                "unknown_payload", "StartTimestamp", default="<unknown-StartTimestamp>"
+            ),
+            "SessionId": event.deep_get(
+                "unknown_payload", "SessionId", default="<unknown-SessionId>"
+            ),
             "Actor": event.deep_get("unknown_payload", "UserName", default="<unknown-UserName>"),
-            "Target Host": event.deep_get("unknown_payload", "HostnameField", default="<unknown-HostnameField>"),
+            "Target Host": event.deep_get(
+                "unknown_payload", "HostnameField", default="<unknown-HostnameField>"
+            ),
         }
 
     return detection.Rule(
@@ -37,9 +46,11 @@ def real_time_response_session(
         log_types=[schema.LogTypeCrowdstrikeFDREvent, schema.LogTypeCrowdstrikeUnknown],
         tags=rule_tags(),
         severity=detection.SeverityMedium,
-        description="Alert when someone uses Crowdstrike’s RTR (real-time response) capability to access a machine "
+        description="Alert when someone uses Crowdstrike’s RTR (real-time response) capability "
+        "to access a machine "
         "remotely to run commands.",
-        reference="https://falcon.us-2.crowdstrike.com/documentation/71/real-time-response-and-network-containment#"
+        reference="https://falcon.us-2.crowdstrike.com/documentation/71/"
+        "real-time-response-and-network-containment#"
         "reviewing-real-time-response-audit-logs",
         runbook="Validate the real-time response session started by the Actor.",
         filters=[

--- a/panther_detections/providers/okta/queries/all_queries.py
+++ b/panther_detections/providers/okta/queries/all_queries.py
@@ -21,7 +21,10 @@ def activity_audit(
     overrides: query.QueryOverrides = query.QueryOverrides(),
     extensions: query.QueryExtensions = query.QueryExtensions(),
 ) -> query.Query:
-    """Audit user activity across your environment. Customize to filter on specfic users, time ranges, etc"""
+    """Audit user activity across your environment.
+
+    Customize to filter on specfic users, time ranges, etc
+    """
 
     sql = """
       SELECT actor:displayName AS actor_name, actor:alternateId AS actor_email, eventType, COUNT(*) AS activity_count
@@ -65,7 +68,7 @@ def admin_access_granted(
     overrides: query.QueryOverrides = query.QueryOverrides(),
     extensions: query.QueryExtensions = query.QueryExtensions(),
 ) -> query.Query:
-    """Audit instances of admin access granted in your okta tenant"""
+    """Audit instances of admin access granted in your okta tenant."""
 
     sql = """
       SELECT 
@@ -137,7 +140,7 @@ def mfa_password_reset_audit(
     overrides: query.QueryOverrides = query.QueryOverrides(),
     extensions: query.QueryExtensions = query.QueryExtensions(),
 ) -> query.Query:
-    """Investigate Password and MFA resets for the last 7 days"""
+    """Investigate Password and MFA resets for the last 7 days."""
 
     sql = """
       SELECT p_event_time,actor:alternateId as actor_user,target[0]:alternateId as target_user, eventType,client:ipAddress as ip_address
@@ -176,7 +179,7 @@ def session_id_audit(
     overrides: query.QueryOverrides = query.QueryOverrides(),
     extensions: query.QueryExtensions = query.QueryExtensions(),
 ) -> query.Query:
-    """Search for activity releated to a specific SessionID in Okta panther_logs.okta_systemlog"""
+    """Search for activity releated to a specific SessionID in Okta panther_logs.okta_systemlog."""
 
     sql = """
         SELECT  
@@ -224,7 +227,8 @@ def session_id_audit(
         name="Okta Investigate Session ID Activity",
         enabled=True,
         sql=sql,
-        description="Search for activity releated to a specific SessionID in Okta panther_logs.okta_systemlog",
+        description="Search for activity releated to a specific SessionID in Okta "
+        "panther_logs.okta_systemlog",
         schedule=default_query_schedule,
     )
 
@@ -234,7 +238,7 @@ def support_access(
     overrides: query.QueryOverrides = query.QueryOverrides(),
     extensions: query.QueryExtensions = query.QueryExtensions(),
 ) -> query.Query:
-    """Show instances that Okta support was granted to your account"""
+    """Show instances that Okta support was granted to your account."""
 
     sql = """
       SELECT 

--- a/panther_detections/providers/okta/rules/admin_actions.py
+++ b/panther_detections/providers/okta/rules/admin_actions.py
@@ -3,12 +3,7 @@ from panther_sdk import PantherEvent, detection, schema
 from panther_detections.utils import match_filters
 
 from .. import sample_logs
-from .._shared import (
-    SHARED_SUMMARY_ATTRS,
-    create_alert_context,
-    rule_tags,
-    standard_tags,
-)
+from .._shared import SHARED_SUMMARY_ATTRS, create_alert_context, rule_tags, standard_tags
 
 __all__ = [
     "admin_disabled_mfa",
@@ -20,7 +15,7 @@ def admin_disabled_mfa(
     overrides: detection.RuleOverrides = detection.RuleOverrides(),
     extensions: detection.RuleExtensions = detection.RuleExtensions(),
 ) -> detection.Rule:
-    """An admin user has disabled the MFA requirement for your Okta account"""
+    """An admin user has disabled the MFA requirement for your Okta account."""
 
     def _title(event: PantherEvent) -> str:
         return f"Okta System-wide MFA Disabled by Admin User {event.udm('actor_user')}"
@@ -38,7 +33,8 @@ def admin_disabled_mfa(
         reports={detection.ReportKeyMITRE: ["TA0005:T1556"]},
         severity=detection.SeverityHigh,
         description="An admin user has disabled the MFA requirement for your Okta account",
-        reference="https://developer.okta.com/docs/reference/api/event-types/?q=system.mfa.factor.deactivate",
+        reference="https://developer.okta.com/docs/reference/api/event-types/"
+        "?q=system.mfa.factor.deactivate",
         runbook="Contact Admin to ensure this was sanctioned activity",
         filters=match_filters.deep_equal("eventType", "system.mfa.factor.deactivate"),
         alert_title=_title,
@@ -63,7 +59,7 @@ def admin_role_assigned(
     overrides: detection.RuleOverrides = detection.RuleOverrides(),
     extensions: detection.RuleExtensions = detection.RuleExtensions(),
 ) -> detection.Rule:
-    """A user has been granted administrative privileges in Okta"""
+    """A user has been granted administrative privileges in Okta."""
 
     def _title(event: PantherEvent) -> str:
         target = event.get("target", [{}])
@@ -103,12 +99,15 @@ def admin_role_assigned(
             fallback=detection.SeverityInfo,
         ),
         description="A user has been granted administrative privileges in Okta",
-        reference="https://help.okta.com/en/prod/Content/Topics/Security/administrators-admin-comparison.htm",
+        reference="https://help.okta.com/en/prod/Content/Topics/Security/"
+        "administrators-admin-comparison.htm",
         runbook="Reach out to the user if needed to validate the activity",
         filters=[
             match_filters.deep_equal("eventType", "user.account.privilege.grant"),
             match_filters.deep_equal("outcome.result", "SUCCESS"),
-            match_filters.deep_equal_pattern("debugContext.debugData.privilegeGranted", r"[aA]dministrator"),
+            match_filters.deep_equal_pattern(
+                "debugContext.debugData.privilegeGranted", r"[aA]dministrator"
+            ),
         ],
         alert_title=_title,
         alert_context=create_alert_context,

--- a/panther_detections/providers/okta/rules/api_keys.py
+++ b/panther_detections/providers/okta/rules/api_keys.py
@@ -15,11 +15,13 @@ def api_key_created(
     overrides: detection.RuleOverrides = detection.RuleOverrides(),
     extensions: detection.RuleExtensions = detection.RuleExtensions(),
 ) -> detection.Rule:
-    """A user created an API Key in Okta"""
+    """A user created an API Key in Okta."""
 
     def _title(event: PantherEvent) -> str:
         target = event.get("target", [{}])
-        key_name = target[0].get("displayName", "MISSING DISPLAY NAME") if target else "MISSING TARGET"
+        key_name = (
+            target[0].get("displayName", "MISSING DISPLAY NAME") if target else "MISSING TARGET"
+        )
 
         return (
             f"{event.deep_get('actor', 'displayName')} <{event.deep_get('actor', 'alternateId')}>"
@@ -61,14 +63,17 @@ def api_key_revoked(
     overrides: detection.RuleOverrides = detection.RuleOverrides(),
     extensions: detection.RuleExtensions = detection.RuleExtensions(),
 ) -> detection.Rule:
-    """A user has revoked an API Key in Okta"""
+    """A user has revoked an API Key in Okta."""
 
     def _title(event: PantherEvent) -> str:
         target = event.get("target", [{}])
-        key_name = target[0].get("displayName", "MISSING DISPLAY NAME") if target else "MISSING TARGET"
+        key_name = (
+            target[0].get("displayName", "MISSING DISPLAY NAME") if target else "MISSING TARGET"
+        )
 
         return (
-            f"{event.get('actor', {}).get('displayName')} <{event.get('actor', {}).get('alternateId')}>"
+            f"{event.get('actor', {}).get('displayName')} "
+            f"<{event.get('actor', {}).get('alternateId')}>"
             f"revoked API key - <{key_name}>"
         )
 

--- a/panther_detections/providers/okta/rules/improbable_access.py
+++ b/panther_detections/providers/okta/rules/improbable_access.py
@@ -49,8 +49,12 @@ def geo_improbable_access_filter() -> detection.PythonFilter:
                     dumps(
                         {
                             "city": event.deep_get("client", "geographicalContext", "city"),
-                            "lon": event.deep_get("client", "geographicalContext", "geolocation", "lon"),
-                            "lat": event.deep_get("client", "geographicalContext", "geolocation", "lat"),
+                            "lon": event.deep_get(
+                                "client", "geographicalContext", "geolocation", "lon"
+                            ),
+                            "lat": event.deep_get(
+                                "client", "geographicalContext", "geolocation", "lat"
+                            ),
                             "time": event.get("p_event_time"),
                             "old_city": old_city,
                         }
@@ -76,7 +80,8 @@ def geo_improbable_access_filter() -> detection.PythonFilter:
         login_key = f"Okta.Login.GeographicallyImprobable{event.deep_get('actor', 'alternateId')}"
         # Retrieve the prior login info from the cache, if any
         last_login = get_string_set(login_key)
-        # If we haven't seen this user login recently, store this login for future use and don't alert
+        # If we haven't seen this user login recently, store this login for future use
+        # and don't alert
         if not last_login:
             store_login_info(login_key)
             return False
@@ -109,7 +114,7 @@ def geo_improbable_access(
     overrides: detection.RuleOverrides = detection.RuleOverrides(),
     extensions: detection.RuleExtensions = detection.RuleExtensions(),
 ) -> detection.Rule:
-    """A user has subsequent logins from two geographic locations that are very far apart"""
+    """A user has subsequent logins from two geographic locations that are very far apart."""
 
     def _title(event: PantherEvent) -> str:
         from panther_oss_helpers import get_string_set  # type: ignore

--- a/panther_detections/providers/okta/rules/support_actions.py
+++ b/panther_detections/providers/okta/rules/support_actions.py
@@ -22,7 +22,7 @@ def account_support_access(
     overrides: detection.RuleOverrides = detection.RuleOverrides(),
     extensions: detection.RuleExtensions = detection.RuleExtensions(),
 ) -> detection.Rule:
-    """Detects when an admin user has granted access to Okta Support for your account"""
+    """Detects when an admin user has granted access to Okta Support for your account."""
 
     def _title(event: PantherEvent) -> str:
         return f"Okta Support Access Granted by {event.udm('actor_user')}"
@@ -37,7 +37,8 @@ def account_support_access(
         reports={detection.ReportKeyMITRE: ["TA0001:T1199"]},
         severity=detection.SeverityMedium,
         description="An admin user has granted access to Okta Support to your account",
-        reference="https://help.okta.com/en/prod/Content/Topics/Settings/settings-support-access.htm",
+        reference="https://help.okta.com/en/prod/Content/Topics/Settings/"
+        "settings-support-access.htm",
         runbook="Contact Admin to ensure this was sanctioned activity",
         filters=[
             match_filters.deep_in("eventType", SUPPORT_ACCESS_EVENTS),
@@ -64,7 +65,7 @@ def support_reset(
     overrides: detection.RuleOverrides = detection.RuleOverrides(),
     extensions: detection.RuleExtensions = detection.RuleExtensions(),
 ) -> detection.Rule:
-    """A Password or MFA factor was reset by Okta Support"""
+    """A Password or MFA factor was reset by Okta Support."""
 
     def _title(event: PantherEvent) -> str:
         return f"Okta Support Reset Password or MFA for user {event.udm('actor_user')}"

--- a/panther_detections/utils/match_filters.py
+++ b/panther_detections/utils/match_filters.py
@@ -6,7 +6,7 @@ __all__ = ["deep_equal", "deep_equal_pattern", "deep_in"]
 
 
 def deep_exists(path: str) -> detection.PythonFilter:
-    """Returns True when a value at the provided path exists"""
+    """Returns True when a value at the provided path exists."""
 
     def _deep_exists(event: PantherEvent) -> bool:
         import collections
@@ -26,7 +26,7 @@ def deep_exists(path: str) -> detection.PythonFilter:
 
 
 def deep_not_exists(path: str) -> detection.PythonFilter:
-    """Returns True when a value at the provided path does not exist"""
+    """Returns True when a value at the provided path does not exist."""
 
     def _deep_not_exists(event: PantherEvent) -> bool:
         import collections
@@ -46,7 +46,7 @@ def deep_not_exists(path: str) -> detection.PythonFilter:
 
 
 def deep_equal(path: str, value: typing.Any) -> detection.PythonFilter:
-    """Returns True when the provided value equals the value at the provided path"""
+    """Returns True when the provided value equals the value at the provided path."""
 
     def _deep_equal(event: PantherEvent) -> bool:
         import collections
@@ -66,7 +66,7 @@ def deep_equal(path: str, value: typing.Any) -> detection.PythonFilter:
 
 
 def deep_not_equal(path: str, value: typing.Any) -> detection.PythonFilter:
-    """Returns True when the provided value does not equal the value at the provided path"""
+    """Returns True when the provided value does not equal the value at the provided path."""
 
     def _deep_not_equal(event: PantherEvent) -> bool:
         import collections
@@ -86,7 +86,8 @@ def deep_not_equal(path: str, value: typing.Any) -> detection.PythonFilter:
 
 
 def deep_equal_pattern(path: str, pattern: str) -> detection.PythonFilter:
-    """Returns True when the provided pattern matches the value at the provided path using the 're' module"""
+    """Returns True when the provided pattern matches the value at the provided path using the 're'
+    module."""
 
     def _deep_equal_pattern(evt: PantherEvent) -> bool:
         import collections
@@ -108,7 +109,8 @@ def deep_equal_pattern(path: str, pattern: str) -> detection.PythonFilter:
 
 
 def deep_not_equal_pattern(path: str, pattern: str) -> detection.PythonFilter:
-    """Returns True when the provided pattern does not match the value at the provided path using the 're' module"""
+    """Returns True when the provided pattern does not match the value at the provided path using
+    the 're' module."""
 
     def _deep_not_equal_pattern(evt: PantherEvent) -> bool:
         import collections
@@ -130,7 +132,7 @@ def deep_not_equal_pattern(path: str, pattern: str) -> detection.PythonFilter:
 
 
 def deep_in(path: str, value: typing.List[typing.Any]) -> detection.PythonFilter:
-    """Returns True when one of the provided values are equal to the value at the provided path"""
+    """Returns True when one of the provided values are equal to the value at the provided path."""
 
     def _deep_in(evt: PantherEvent) -> bool:
         import collections
@@ -152,7 +154,7 @@ def deep_in(path: str, value: typing.List[typing.Any]) -> detection.PythonFilter
 
 
 def deep_not_in(path: str, value: typing.List[typing.Any]) -> detection.PythonFilter:
-    """Returns True when none of the provided values are equal to the value at the provided path"""
+    """Returns True when none of the provided values are equal to the value at the provided path."""
 
     def _deep_not_in(evt: PantherEvent) -> bool:
         import collections
@@ -174,7 +176,7 @@ def deep_not_in(path: str, value: typing.List[typing.Any]) -> detection.PythonFi
 
 
 def deep_less_than(path: str, value: typing.Union[int, float]) -> detection.PythonFilter:
-    """Returns True if the value at the provided path is less than a value"""
+    """Returns True if the value at the provided path is less than a value."""
 
     def _deep_less_than(evt: PantherEvent) -> bool:
         import collections
@@ -196,7 +198,7 @@ def deep_less_than(path: str, value: typing.Union[int, float]) -> detection.Pyth
 
 
 def deep_less_than_or_equal(path: str, value: typing.Union[int, float]) -> detection.PythonFilter:
-    """Returns True if the value at the provided path is less than or equal to a value"""
+    """Returns True if the value at the provided path is less than or equal to a value."""
 
     def _deep_less_than_or_equal(evt: PantherEvent) -> bool:
         import collections
@@ -218,7 +220,7 @@ def deep_less_than_or_equal(path: str, value: typing.Union[int, float]) -> detec
 
 
 def deep_greater_than(path: str, value: typing.Union[int, float]) -> detection.PythonFilter:
-    """Returns True if the value at the provided path is greater than a value"""
+    """Returns True if the value at the provided path is greater than a value."""
 
     def _deep_greater_than(evt: PantherEvent) -> bool:
         import collections
@@ -239,8 +241,10 @@ def deep_greater_than(path: str, value: typing.Union[int, float]) -> detection.P
     )
 
 
-def deep_greater_than_or_equal(path: str, value: typing.Union[int, float]) -> detection.PythonFilter:
-    """Returns True if the value at the provided path is greater than or equal to a value"""
+def deep_greater_than_or_equal(
+    path: str, value: typing.Union[int, float]
+) -> detection.PythonFilter:
+    """Returns True if the value at the provided path is greater than or equal to a value."""
 
     def _deep_greater_than_or_equal(evt: PantherEvent) -> bool:
         import collections
@@ -266,7 +270,8 @@ def deep_between(
     val_min: typing.Union[int, float],
     val_max: typing.Union[int, float],
 ) -> detection.PythonFilter:
-    """Returns True if the value at the provided path is between (or equal to) a maximum and minimum"""
+    """Returns True if the value at the provided path is between (or equal to) a maximum and
+    minimum."""
 
     if val_min >= val_max:
         raise RuntimeError("deep_between: min must be greater than max")
@@ -295,7 +300,8 @@ def deep_between_exclusive(
     val_min: typing.Union[int, float],
     val_max: typing.Union[int, float],
 ) -> detection.PythonFilter:
-    """Returns True if the value at the provided path is between, but not equal to, a maximum and minimum"""
+    """Returns True if the value at the provided path is between, but not equal to, a maximum and
+    minimum."""
 
     if val_min >= val_max:
         raise RuntimeError("deep_between_exclusive: min must be greater than max")


### PR DESCRIPTION
### Background

I aligned the line-length lint check with panther-analysis to 100 characters. 80 characters is recommended as a maximum character length per line by several sources, including [w3](https://www.w3.org/WAI/tutorials/page-structure/styling/#line-length) and [the code formatter black](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length). I am a user who increases the default font size, and this setting makes a difference for me. 

I converted the `make test` target to do things with `coverage` and the stdlib's unittest. [Nose has been EOL for several years](https://nose.readthedocs.io/en/latest/), and it appeared that the unit testing usage in this repo was not nose specific. 

I modified the `make install` command to install dependencies as prescribed in the Pipfile.lock, in order to contract dependency  resolution behavior. When `make install` runs `pip install`, pip scans pypi for the latest version of all package that meet the version constraints in the Pipfile.  This can lead to inconsistent dependency versions at merge time and how deps are resolved in downstream callers. 

### Changes

* turned line-length checks down to 100 characters
* tweaked a few docstrings that the linter refused to autoformat 
* convert the nose calls to coverage + unittest 
    * Updated the Pipfile/.lock to remove nose and include coverage  

### Testing

* `make lint`
* `make test`
