### PR TITLE
modify setup file to include find_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from setuptools import setup, find_packages
 
 this_directory = Path(__file__).parent
-VERSION = "0.0.9"
+VERSION = "0.0.8"
 
 setup(
     name="panther_detections",

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 from pathlib import Path
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 this_directory = Path(__file__).parent
-VERSION = "0.0.7"
+VERSION = "0.0.9"
 
 setup(
     name="panther_detections",
     version=VERSION,
-    packages=["panther_detections"],
+    packages=find_packages(),
     package_data={"panther_detections": ["py.typed"]},
     license="AGPL-3.0",
     description="",


### PR DESCRIPTION
### Background

Need to use find_packages to make them auto-discoverable.

### Changes

* revert change to find packages

### Testing

* Tested in panther-content-repo that the sub packages are now discoverable:

```
(my-panther-content) [15:38:46] √  pip3 install -e ~/github/dev/panther-detections  
  Preparing metadata (setup.py) ... done
Installing collected packages: panther-detections
  Attempting uninstall: panther-detections
    Found existing installation: panther-detections 0.0.9
    Uninstalling panther-detections-0.0.9:
      Successfully uninstalled panther-detections-0.0.9
  Running setup.py develop for panther-detections
Successfully installed panther-detections-0.0.10

(my-panther-content) [15:39:37] √ mypy --config-file mypy.ini panther_content tests
Success: no issues found in 14 source files
```
